### PR TITLE
add helper methods

### DIFF
--- a/lib/shackles.rb
+++ b/lib/shackles.rb
@@ -18,6 +18,7 @@ module Shackles
     def initialize!
       require 'shackles/connection_handler'
       require 'shackles/connection_specification'
+      require 'shackles/helper_methods'
 
       activated_environments << Shackles.environment
 

--- a/lib/shackles/helper_methods.rb
+++ b/lib/shackles/helper_methods.rb
@@ -1,0 +1,36 @@
+module Shackles
+  module HelperMethods
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # see readme for example usage
+    module ClassMethods
+      def shackle_class_methods(*methods, opts)
+        methods.each { |m| shackle_class_method(m, opts) }
+      end
+
+      def shackle_class_method(method, opts)
+        self.singleton_class.shackle_method(method, opts)
+      end
+
+      def shackle_methods(*methods, opts)
+        methods.each { |m| shackle_method(m, opts) }
+      end
+
+      def shackle_method(method, opts)
+        @shackles_module ||= begin
+          m = Module.new
+          self.prepend m
+          m
+        end
+
+        @shackles_module.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+         def #{method}(*args)
+           Shackles.activate(#{opts[:environment].inspect}) { super }
+         end
+        RUBY
+      end
+    end
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -49,3 +49,27 @@ if ENV['RAILS_DATABASE_USER']
   Shackles.apply_config!(:username => ENV['RAILS_DATABASE_USER'])
 end
 ```
+
+Additionally **in Ruby 2.0+** you can include Shackles::HelperMethods and use several helpers
+to execute methods on specific environments:
+
+```ruby
+class SomeModel
+  include Shackles::HelperMethods
+
+  def expensive_read_only
+    ...
+  end
+  shackle_method :expensive_read_only, environment: :slave
+
+  def self.class_level_expensive_read_only
+    ...
+  end
+  shackle_class_method :class_level_expensive_read_only, environment: :slave
+
+  # helpers for multiple methods are also available
+
+  shackle_methods :instance_method_foo, :instance_method_bar, environment: :slave
+  shackle_class_methods :class_method_foo, :class_method_bar, environment: :slave
+end
+```


### PR DESCRIPTION
adding this would allow us to include Shackles::HelperMethods in AR::Base and then we could wrap shackle_method(s) in helper functions defined in Canvas so we could then just call 'slave_method :foo_method_name' from a class