### PR TITLE
Adds Rails 5 compatibility for ConnectionSpecification

### DIFF
--- a/lib/shackles/connection_specification.rb
+++ b/lib/shackles/connection_specification.rb
@@ -31,8 +31,14 @@ module Shackles
       end
     end
 
-    def initialize(config, adapter_method)
-      super(config.deep_symbolize_keys, adapter_method)
+    if Rails::VERSION::MAJOR >= 5
+      def initialize(id, config, adapter_method)
+        super(id, config.deep_symbolize_keys, adapter_method)
+      end
+    else
+      def initialize(config, adapter_method)
+        super(config.deep_symbolize_keys, adapter_method)
+      end
     end
 
     def config


### PR DESCRIPTION
Adds support for the refactoring of `ConnectionSpecification`'s `initialize` method from https://github.com/rails/rails/commit/b83fb847337b690ebbc96c55414157f71bbf8aa2#diff-9220267c89717bc78a987fe6d4439c72
